### PR TITLE
Changed processing of combos

### DIFF
--- a/MuayThaideas/src/screens/Workout.js
+++ b/MuayThaideas/src/screens/Workout.js
@@ -35,6 +35,21 @@ const WorkoutScreen = () => {
     return `${minutes} minutes, ${seconds} seconds`;
   };
 
+  const handleSetComboList = (result) => {
+    let comboList = [];
+  
+    if (result.rows.length > 0) {
+      for (let i = comboList.length; i < result.rows.length; i++) {
+        comboList[i] = result.rows._array[i].combo;
+      }
+    }
+  
+    assignRandomCombo(comboList);
+  }
+
+  useEffect(() => {
+    getRandomCombo();
+  }, []);
 
   useEffect(() => {
     if (!isWorkoutPaused) {
@@ -48,13 +63,7 @@ const WorkoutScreen = () => {
 
   useEffect(() => {
     if (overallTimeRemaining === 0) {
-      navigation.navigate('WorkoutEndScreen');
-    }
-  }, [overallTimeRemaining, navigation]);
-
-  useEffect(() => {
-    if (overallTimeRemaining === 0) {
-      navigation.navigate('WorkoutEndScreen');
+      navigation.navigate('WorkoutSetup');
     }
   }, [overallTimeRemaining, navigation]);
 
@@ -71,7 +80,6 @@ const WorkoutScreen = () => {
 
   useEffect(() => {
     if (isRoundActive && !isWorkoutPaused) {
-      getRandomCombo();
       const roundTimer = setInterval(() => {
         setRoundTimeRemaining((prev) => (prev > 0 ? prev - 1 : 0));
       }, 1000);
@@ -100,7 +108,7 @@ const WorkoutScreen = () => {
       setIsRoundActive(true);
       setRestTimeRemaining(restTime);
       setRoundTimeRemaining(roundTime * 60);
-      setRandomCombo();
+      getRandomCombo();
     }
   }, [roundTimeRemaining, restTimeRemaining]);
 
@@ -110,13 +118,19 @@ const WorkoutScreen = () => {
     }
   }, [overallTimeRemaining, navigation]);
 
+
+  assignRandomCombo = (comboList) => {
+      const rng = RNG(0, comboList.length);
+      setRandomCombo(comboList[rng]);
+    }
+  
+
   function grabUserCombo(){
     ComboList.grabRandomUserCombo((error, result) => {
       if (error) {
         console.error(error);
       } else {
-        console.log(result)
-        setRandomCombo(result);
+        handleSetComboList(result);
       }
     });
   }
@@ -126,8 +140,7 @@ const WorkoutScreen = () => {
       if (error) {
         console.error(error);
       } else {
-        console.log(result)
-        setRandomCombo(result);
+        handleSetComboList(result);
       }
     });
   }
@@ -137,54 +150,22 @@ const WorkoutScreen = () => {
       if (error) {
         console.error(error);
       } else {
-        console.log(result)
-        setRandomCombo(result);
+        handleSetComboList(result);
       }
     });
   }
 
   function getRandomCombo(){ 
-    //if you see this, I am very tired and my brain won't think of a better way
-    if(beginner && !advanced && !userToggle){
+    if(beginner){
       grabBuiltinBeginnerCombo();
-    } else if (advanced && !beginner && !userToggle) {
+    }
+
+    if(advanced){
       grabBuiltinAdvancedCombo();
-    } else if (userToggle && !beginner && !advanced){
+    }
+
+    if(userToggle){
       grabUserCombo();
-    } else if (beginner && advanced && !userToggle){
-      if(RNG(0, 1) === 0){
-        grabBuiltinBeginnerCombo();
-      } else if (RNG(0, 1) === 1){
-        grabBuiltinAdvancedCombo();
-      }
-    } else if (!beginner && advanced && userToggle){
-      if(RNG(0, 1) === 0){
-        grabUserCombo();
-      } else if (RNG(0, 1) === 1){
-        grabBuiltinAdvancedCombo();
-      }
-    } else if (beginner && advanced && userToggle){
-      if(RNG(0, 1) === 0){
-        grabBuiltinBeginnerCombo();
-      } else if (RNG(0, 1) === 1){
-        grabBuiltinAdvancedCombo();
-      } else if (RNG(0, 1) === 2){
-        grabUserCombo();
-      }
-    } else if (beginner && !advanced && userToggle){
-      if(RNG(0, 1) === 0){
-        grabBuiltinBeginnerCombo();
-      } else if (RNG(0, 1) === 1){
-        grabUserCombo();
-      }
-    } else if (beginner && advanced && userToggle) {
-      if(RNG(0,2) === 0){
-        grabBuiltinAdvancedCombo();
-      } else if (RNG(0,2) == 1){
-        grabBuiltinBeginnerCombo();
-      } else if (RNG(0,2) == 2){
-        grabUserCombo();
-      }
     }
   }
 
@@ -198,12 +179,9 @@ const WorkoutScreen = () => {
 
   const handleSkip = () => {
     if(isRoundActive){
-      setIsRoundActive(false);
-      setRoundTimeRemaining(roundTime * 60);
-      setRandomCombo(null)
+      setRoundTimeRemaining(1);
     } else {
-      setIsRoundActive(true);
-      setRestTimeRemaining(restTime);
+      setRestTimeRemaining(1);
     }
   };
 

--- a/MuayThaideas/src/utils/database.js
+++ b/MuayThaideas/src/utils/database.js
@@ -297,25 +297,8 @@ function grabRandomUserCombo(callback) {
         'SELECT * FROM combos',
         null,
         (_, resultSet) => {
-          // Check if there is at least one row
-          console.log(resultSet.rows.length)
           if (resultSet.rows.length > 0) {
-            const randomCombo = resultSet
-              .rows
-                .item(Math
-                  .floor(Math
-                    .random() * ((resultSet.rows.length-1) - 0 + 1)) + 0)
-                      .combo;        
-            callback(null, randomCombo);
-          } else {
-              Alert.alert('No User Combos Found', 'Please create combos in the Combo List, or select the builtin combo categories.', [
-                {
-                  text: 'OK',
-                  onPress: () => {
-                    callback('No combos found');
-                  },
-                },
-              ]);
+            callback(null, resultSet);
           }
         },
         (_, error) => callback(error)
@@ -339,14 +322,8 @@ function grabRandomBuiltinBeginnerCombo(callback) {
         (_, resultSet) => {
           // Check if there is at least one row
           console.log(resultSet.rows.length)
-          if (resultSet.rows.length > 0) {
-            const randomCombo = resultSet
-              .rows
-                .item(Math
-                  .floor(Math
-                    .random() * ((resultSet.rows.length-1) - 0 + 1)) + 0)
-                      .combo;        
-            callback(null, randomCombo);
+          if (resultSet.rows.length > 0) {   
+            callback(null, resultSet);
           } else {
             callback('No combos found');
           }
@@ -371,14 +348,8 @@ function grabRandomBuiltinAdvancedCombo(callback) {
         (_, resultSet) => {
 
           console.log(resultSet.rows.length)
-          if (resultSet.rows.length > 0) {
-            const randomCombo = resultSet
-              .rows
-                .item(Math
-                  .floor(Math
-                    .random() * ((resultSet.rows.length-1) - 0 + 1)) + 0)
-                      .combo;        
-            callback(null, randomCombo);
+          if (resultSet.rows.length > 0) {    
+            callback(null, resultSet);
           } else {
             callback('No combos found');
           }


### PR DESCRIPTION
Combinations are now appended to an array based on what toggles were selected.

This allows for a more robust gathering system, as well as the feel of more "randomness" for the user.

Previously, the split was equal: if the user had 1 combo in "User", and 20 in "beginner" they'd still likely see their single "user" combo 50% of the time. Now, they should see it an appropriate 1/21 times.

These changes also fix the issue with the REST message being too often left on screen - as well as the pause button causing new combos to appear.